### PR TITLE
Minor perf improvements in parseTreeInfo()

### DIFF
--- a/gen/parse.go
+++ b/gen/parse.go
@@ -71,9 +71,9 @@ func readTrees(x *xgbModel) ([]*node, error) {
 }
 
 type node struct {
-	data  nodeData
 	left  *node
 	right *node
+	data  nodeData
 }
 
 type nodeData struct {
@@ -92,11 +92,7 @@ func parseTreeInfo(xt xgbTree) (*node, error) {
 		)
 	}
 
-	var nodes []*node
-	for i := 0; i < int(numNodes); i++ {
-		nodes = append(nodes, &node{})
-	}
-
+	nodes := make([]node, numNodes)
 	for i := 0; i < int(numNodes); i++ {
 		nodes[i].data = nodeData{
 			DefaultLeft:    xt.DefaultLeft[i],
@@ -112,9 +108,9 @@ func parseTreeInfo(xt xgbTree) (*node, error) {
 			continue
 		}
 
-		nodes[i].left = nodes[left]
-		nodes[i].right = nodes[right]
+		nodes[i].left = &nodes[left]
+		nodes[i].right = &nodes[right]
 	}
 
-	return nodes[0], nil // Root node
+	return &nodes[0], nil // Root node
 }

--- a/gen/parse_test.go
+++ b/gen/parse_test.go
@@ -126,3 +126,15 @@ func TestParseTreeInfo(t *testing.T) {
 		treeInfo,
 	)
 }
+
+func BenchmarkParseTreeInfo(b *testing.B) {
+	x, err := readModel(filepath.Join("testdata", "small-model", "model.json"))
+	require.NoError(b, err)
+	tree := x.Learner.GradientBooster.Model.Trees[0]
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := parseTreeInfo(tree)
+		require.NoError(b, err)
+	}
+}

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -62,10 +62,10 @@ func indent(level int) string {
 }
 
 type decisionNodeParams struct {
-	nodeData
 	Left  string
-	Level int
 	Right string
+	Level int
+	nodeData
 }
 
 func (r *renderer) executeDecisionNode(


### PR DESCRIPTION


```sh
$ benchstat old.txt new.txt 
goos: darwin
goarch: arm64
pkg: github.com/maxmind/xgb2code/gen
                 │   old.txt   │               new.txt               │
                 │   sec/op    │   sec/op     vs base                │
ParseTreeInfo-10   584.5n ± 1%   231.9n ± 1%  -60.32% (p=0.000 n=10)

                 │  old.txt   │              new.txt               │
                 │    B/op    │    B/op     vs base                │
ParseTreeInfo-10   872.0 ± 0%   640.0 ± 0%  -26.61% (p=0.000 n=10)

                 │   old.txt   │              new.txt               │
                 │  allocs/op  │ allocs/op   vs base                │
ParseTreeInfo-10   18.000 ± 0%   1.000 ± 0%  -94.44% (p=0.000 n=10)
```

<details>
<summary>before</summary>

```sh
$ go test -run=^$ -bench=. -benchmem -count=10 ./gen | tee old.txt 
goos: darwin
goarch: arm64
pkg: github.com/maxmind/xgb2code/gen
BenchmarkParseTreeInfo-10    	 2012709	       581.7 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2064264	       586.4 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2045088	       587.9 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2061264	       583.6 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2076304	       586.3 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2064022	       583.2 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2058519	       584.5 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 1977475	       584.5 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2059624	       588.7 ns/op	     872 B/op	      18 allocs/op
BenchmarkParseTreeInfo-10    	 2048594	       583.1 ns/op	     872 B/op	      18 allocs/op
PASS
ok  	github.com/maxmind/xgb2code/gen	18.236s
```

</details>

<details>
<summary>after</summary>

```sh
$ go test -run=^$ -bench=. -benchmem -count=10 ./gen | tee new.txt
goos: darwin
goarch: arm64
pkg: github.com/maxmind/xgb2code/gen
BenchmarkParseTreeInfo-10    	 4891856	       232.7 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5157418	       232.1 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5075401	       231.5 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5138415	       231.6 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5186865	       233.6 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5210715	       231.8 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5193562	       231.5 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 4877660	       231.3 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5125712	       232.1 ns/op	     640 B/op	       1 allocs/op
BenchmarkParseTreeInfo-10    	 5221425	       234.9 ns/op	     640 B/op	       1 allocs/op
PASS
ok  	github.com/maxmind/xgb2code/gen	14.573s
```

</details>